### PR TITLE
change use query to use system state

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -33,7 +33,7 @@ fn Editor(cx: Scope) -> Element {
 
 #[component]
 fn SceneTree<'a>(cx: Scope, selected_entity: &'a UseStateSendable<Option<Entity>>) -> Element {
-    let entities = use_query_filtered::<(Entity, DebugName), Without<Node>>(cx);
+    let mut entities = use_query_filtered::<(Entity, DebugName), Without<Node>>(cx);
     let entities = entities.query();
     let mut entities = entities.into_iter().collect::<Vec<_>>();
     entities.sort_by_key(|(entity, _)| *entity);


### PR DESCRIPTION
Tried using SystemState instead of `Query::new` like james suggested. Seems to work, but had to change query() to take an &mut self. Not sure if that would be a deal breaker. Needs to be &mut so that the cached archetypes can be updated.